### PR TITLE
fix readme description of users/authenticate api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ MLAB_DB=<database>
 * Used for signing up a user. Accepts `username`, `email`, and `password` to create a user. Returns a JWT.
 
 #### **POST** `/api/users/authenticate`
-* Used for logging a user in. Accepts `username` or `email` and `password` to authenticate a user. Returns a JWT.
+* Used for logging a user in. Accepts `user` (where you can supply a users `username` or `email`) and `password` to authenticate a user. Returns a JWT.
 
 #### **GET** `/api/users`
 * Returns all users in the database. Requires a valid JWT with an `admin` scope.


### PR DESCRIPTION
the key `user` is required instead of `username` or `email` as described

I get following error when I supply `username` or `email` as described

```json
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "child \"user\" fails because [\"user\" is required]. child \"user\" fails because [\"user\" is required]",
    "validation": {
        "source": "payload",
        "keys": [
            "user",
            "user"
        ]
    }
}
```

but when I just supply `user` containing `username` or `email` I get a JWT back